### PR TITLE
Boldened walrus html's text so it will be more visible on the site

### DIFF
--- a/aquarium/css/walrus.css
+++ b/aquarium/css/walrus.css
@@ -3,6 +3,7 @@ body {
     background-color: rgb(140, 33, 161);
     text-align: center;
     color: azure;
+    font-weight: 900;
 }
 
 img {


### PR DESCRIPTION
 Using font-weight: 900 in the walrus.css file, boldened the text so it could be more visible